### PR TITLE
DTSW-2398 upgrade with local firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,61 @@
-# Template: template-basic
+# dt-firmware-upgrade
 
-This template provides a boilerplate repository for developing non-ROS software
-in Duckietown.
+## Testing Local Firmware
+The steps to test a firmware binary available locally are stated here.
 
-**NOTE:** If you want to develop software that uses ROS, check out
-[this template](https://github.com/duckietown/template-ros).
+### Why we need this
+Previously, the firmware always has to be downloaded from S3 storage, which makes testing new firmware files built locally difficult and slow. This mode avoids having to upload the firmware binaries to S3 and creating indexes for them, before they could be tested with this repo.
 
+### Steps
+1. Clone this repo to your laptop; Navigate to the repo
+1. Build the repo on the Duckiebot with `dts devel build -f --pull -H [DUCKIEBOT_HOSTNAME]` from your laptop
+1. On your laptop, copy the firmware `xxx.bin` file to `assets/firmware` of the cloned repo, and rename the copied file to `fw.bin`.
+1. To start a container with the local files mounted on the Duckiebot, run the firmware upgrade container with `dts devel run -M -s -f -c bash -H autobot33 -- --privileged -it`
+1. Then, in the shell from the previous step, run the upgrade module with the extra argument `--use-local-firmware`
 
-## How to use it
+```
+# Example (in the shell inside the container)
 
-### 1. Fork this repository
+$ python3 -m upgrade_helper.main --battery --use-local-firmware
+```
 
-Use the fork button in the top-right corner of the github page to fork this template repository.
+### Expected logs on terminal
 
+#### A successful run
+```
+root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --use-local-firmware
+INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]
 
-### 2. Create a new repository
+Duckietown Battery Firmware Upgrade Utility.
+Version 0.0.2
 
-Create a new repository on github.com while
-specifying the newly forked template repository as
-a template for your new repository.
+INFO:UpgradeHelper:In local firmware testing mode, will NOT download firmware from server.
+INFO:UpgradeHelper:Using firmware file: /code/dt-firmware-upgrade/assets/firmware/fw.bin
+INFO:UpgradeHelper:Flashing firmware to device ttyACM0...
+Atmel SMART device 0x10030000 found
+Erase flash
+done in 0.201 seconds
 
+Write 12204 bytes to flash (191 pages)
+[==============================] 100% (191/191 pages)
+done in 2.388 seconds
 
-### 3. Define dependencies
+Verify 12204 bytes of flash
+[==============================] 100% (191/191 pages)
+Verify successful
+done in 0.070 seconds
+CPU reset.
+INFO:UpgradeHelper:Done!
+```
 
-List the dependencies in the files `dependencies-apt.txt` and
-`dependencies-py3.txt` (apt packages and pip packages respectively).
+#### The binary file wrongly put/named, or not found
+```
+root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --use-local-firmware
+INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]
 
+Duckietown Battery Firmware Upgrade Utility.
+Version 0.0.2
 
-### 4. Place your code
-
-Place your code in the directory `/packages/` of
-your new repository.
-
-
-### 5. Setup launchers
-
-The directory `/launchers` can contain as many launchers (launching scripts)
-as you want. A default launcher called `default.sh` must always be present.
-
-If you create an executable script (i.e., a file with a valid shebang statement)
-a launcher will be created for it. For example, the script file 
-`/launchers/my-launcher.sh` will be available inside the Docker image as the binary
-`dt-launcher-my-launcher`.
-
-When launching a new container, you can simply provide `dt-launcher-my-launcher` as
-command.
+INFO:UpgradeHelper:In local firmware testing mode, will NOT download firmware from server.
+INFO:UpgradeHelper:Error! Local firmware binary NOT FOUND at: /code/dt-firmware-upgrade/assets/firmware/fw.bin
+```

--- a/packages/upgrade_helper/constants.py
+++ b/packages/upgrade_helper/constants.py
@@ -6,6 +6,8 @@ BATTERY_PCB16_BOOT_MODE_PID = "0557"
 BATTERY_FIRMWARE_URL = "https://duckietown-public-storage.s3.amazonaws.com/assets/battery/" \
                        "PCBv{pcb_version}/firmware/{resource}"
 
+# see README file, section "Testing Local Firmware"
+LOCAL_FIRMWARE_BIN_PATH = "assets/firmware/fw.bin"
 
 class ExitCode(IntEnum):
     # This APP communicates the outcome of its actions using these exit codes.

--- a/packages/upgrade_helper/main.py
+++ b/packages/upgrade_helper/main.py
@@ -32,6 +32,12 @@ if __name__ == '__main__':
         default=False,
         help="Pretend you are doing stuff"
     )
+    parser.add_argument(
+        "--use-local-firmware",
+        action="store_true",
+        default=False,
+        help="Try to use the firmware at assets/firmware/fw.bin (to help fast testing with local firmware binaries)"
+    )
     parsed = parser.parse_args()
     # ---
     # run upgrade helper


### PR DESCRIPTION
Added option to use a locally available firmware binary. Such that the firmware does not have to be downloaded from S3.

```
python3 -m upgrade_helper.main -h
usage: main.py [-h] [--battery] [--hut] [--check] [--dry-run] [--use-local-firmware]

optional arguments:
  -h, --help            show this help message and exit
  ...
  --use-local-firmware  Try to use the firmware at assets/firmware/fw.bin (to help fast testing with local firmware binaries)
```

Tested on DB21J with PCBv16, with firmware v202. The logs show whether the firmware used to flash is downloaded from S3, or from local dir.

### From S3

```
# python3 -m upgrade_helper.main --battery
...
INFO:UpgradeHelper:Downloading firmware version v2.0.2...
INFO:UpgradeHelper:Firmware downloaded!
INFO:UpgradeHelper:Using firmware file: /tmp/battery_pcb16_fw_v202.bin
...
```

### From local

```
# python3 -m upgrade_helper.main --battery --use-local-firmware
...
INFO:UpgradeHelper:In local firmware testing mode, will NOT download firmware from server.
INFO:UpgradeHelper:Using firmware file: /code/dt-firmware-upgrade/assets/firmware/fw.bin
...
```