### PR TITLE
Refactor helper and remove hardcode PCB version

### DIFF
--- a/packages/upgrade_helper/constants.py
+++ b/packages/upgrade_helper/constants.py
@@ -1,10 +1,13 @@
 from enum import IntEnum, Enum
 
-BATTERY_PCB16_BOOT_MODE_VID = "16d0"
-BATTERY_PCB16_BOOT_MODE_PID = "0557"
+BATTERY_FIRMWARE_URL = (
+    "https://duckietown-public-storage.s3.amazonaws.com"
+    "/assets/battery/PCBv{pcb_version}/firmware/{resource}"
+) 
 
-BATTERY_FIRMWARE_URL = "https://duckietown-public-storage.s3.amazonaws.com/assets/battery/" \
-                       "PCBv{pcb_version}/firmware/{resource}"
+# in the helper, these env variables help configure some options
+ENV_KEY_FORCE_FW_VERSION = "FORCE_BATTERY_FW_VERSION"
+ENV_KEY_PCB_VERSION = "PCB_VERSION"
 
 # see README file, section "Testing Local Firmware"
 LOCAL_FIRMWARE_BIN_PATH = "assets/firmware/fw.bin"

--- a/packages/upgrade_helper/constants.py
+++ b/packages/upgrade_helper/constants.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 BATTERY_PCB16_BOOT_MODE_VID = "16d0"
 BATTERY_PCB16_BOOT_MODE_PID = "0557"
@@ -19,3 +19,12 @@ class ExitCode(IntEnum):
     FIRMWARE_UP_TO_DATE = 5
     FIRMWARE_NEEDS_UPDATE = 6
     GENERIC_ERROR = 9
+
+# when running main.py with `--find-pcbid`, either return
+#   this: meaning failed to obtain a valid PCB version
+#   other int: the pcb version (e.g. PCBv1.6 => 16, PCBv2.1 => 21)
+PCB_VERSION_ID_EXIT_CODE_NONE = 0
+
+class BatteryMode(Enum):
+    READY = "ready"  # referred to as ready/normal mode
+    BOOT = "boot"

--- a/packages/upgrade_helper/helper.py
+++ b/packages/upgrade_helper/helper.py
@@ -5,7 +5,7 @@ import sys
 import time
 import traceback
 from threading import Thread
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union, Dict
 
 import requests
 import serial
@@ -13,11 +13,22 @@ from serial.tools.list_ports import grep as serial_grep
 
 from battery_drivers import Battery
 from dt_class_utils import DTProcess
-from battery_drivers.constants import BATTERY_PCB16_BOOT_VID, BATTERY_PCB16_BOOT_PID, \
-    BATTERY_PCB16_READY_VID, BATTERY_PCB16_READY_PID, BATTERY_PCB16_BAUD_RATE
+from battery_drivers.constants import (
+    BATTERY_PCB_BOOT_VID,
+    BATTERY_PCB_BOOT_PID,
+    BATTERY_PCB_READY_VID,
+    BATTERY_PCB_READY_PID,
+    BATTERY_PCB_BAUD_RATE,
+)
 
 from . import __version__
-from .constants import ExitCode, BATTERY_FIRMWARE_URL, LOCAL_FIRMWARE_BIN_PATH
+from .constants import (
+    ExitCode,
+    BatteryMode,
+    BATTERY_FIRMWARE_URL,
+    LOCAL_FIRMWARE_BIN_PATH,
+    PCB_VERSION_ID_EXIT_CODE_NONE,
+)
 
 INFO = """
 Duckietown {hardware} Firmware Upgrade Utility.
@@ -36,6 +47,7 @@ class UpgradeHelper(DTProcess):
 
     def __init__(self):
         super(UpgradeHelper, self).__init__("UpgradeHelper")
+        self._battery_info = None
 
     def start(self, parsed) -> int:
         # nothing to do?
@@ -49,119 +61,272 @@ class UpgradeHelper(DTProcess):
         sys.stdout.flush()
         # upgrade battery
         if parsed.battery:
-            return self.upgrade_battery(parsed.check, parsed.dry_run, parsed.use_local_firmware)
+            if parsed.find_pcbid:
+                return self.battery_find_pcb_version()
+            if parsed.check:
+                return self.battery_check_firmware_up_to_date()
+            # try to flash firmware
+            return self.upgrade_battery(
+                parsed.find_pcbid,
+                parsed.check,
+                parsed.dry_run,
+                parsed.use_local_firmware,
+            )
         # upgrade hut
         if parsed.hut:
             return self.upgrade_hut(parsed.check, parsed.dry_run)
 
-    def upgrade_battery(self, check: bool = False, dryrun: bool = False, use_local_firmware: bool = False) -> int:
-        # battery needs to be in boot mode
-        ready_devs = self._find_device(BATTERY_PCB16_READY_VID, BATTERY_PCB16_READY_PID)
-        boot_devs = self._find_device(BATTERY_PCB16_BOOT_VID, BATTERY_PCB16_BOOT_PID)
+    def _battery_device_mode_detect(self,
+                                   mode_required: BatteryMode,
+                                   ) -> Union[int, str]:
+        """Detect battery device address
+
+        battery needs to be:
+          * in ready mode for info/version reading
+          * in boot mode for firmware flashing
+
+        Args:
+            mode_required (BatteryMode): the battery is expected in READY or BOOT mode
+
+        Returns:
+            Union[int, str]: If success, the device port, e.g. "/dev/ttyUSB0".
+                             Otherwise, return an int defined in ExitCode class.
+        """
+
+        ready_devs = self._find_device(BATTERY_PCB_READY_VID, BATTERY_PCB_READY_PID)
+        boot_devs = self._find_device(BATTERY_PCB_BOOT_VID, BATTERY_PCB_BOOT_PID)
         # no battery at all?
         if len(boot_devs) + len(ready_devs) <= 0:
-            # no battery found
-            self.logger.error("Battery not detected. Please, check the connection to the battery "
-                              "and retry.")
+            self.logger.error((
+                "Battery not detected. "
+                "Please check the connection to the battery and retry."
+            ))
             return ExitCode.HARDWARE_NOT_FOUND
-        # pick version
-        if os.environ.get("FORCE_BATTERY_FW_VERSION", default=None) is not None:
-            latest_str = os.environ.get("FORCE_BATTERY_FW_VERSION", default=None)
-            try:
-                latest_int = int(re.sub("[^0-9]+", "", latest_str))
-            except ValueError:
-                # something went wrong
-                self.logger.error("Error parsing the given version string. Exiting.")
-                return ExitCode.GENERIC_ERROR
-            self.logger.info(f"Firmware version forced to {latest_str}")
-        else:
-            # get latest version available
-            latest_int, latest_str = self._get_latest_battery_firmware_available()
-            if latest_int is None:
-                # something went wrong
-                self.logger.error("Error fetching the latest firmware version available "
-                                  "from the internet. Exiting.")
-                return ExitCode.GENERIC_ERROR
-            self.logger.debug(f"Latest version fetched from the cloud is {latest_str}")
-        # two cases:
-        # - check = True: we want a battery in normal mode so that we can read the current version
-        # - check = False: we want a battery in boot mode so that we can flash it
-        if check:
-            # normal mode enabled?
-            if len(ready_devs) <= 0:
-                # battery found but not in normal mode
+
+        # check if mode correct
+        if mode_required == BatteryMode.READY:
+            if len(ready_devs) < 1:
+                # battery found but NOT in NORMAL/READY mode
                 self.logger.error("Battery detected in 'Boot Mode', but it needs to be in "
                                   "'Normal Mode'. You can switch mode by pressing the button "
                                   "on the battery ONCE.")
                 return ExitCode.HARDWARE_WRONG_MODE
+            return ready_devs[0]
+        elif mode_required == BatteryMode.BOOT:
+            if len(boot_devs) < 1:
+                # battery found but NOT in BOOT mode
+                self.logger.error("Battery detected in 'Normal Mode', but it needs to be in "
+                                "'Boot Mode'. You can switch mode by DOUBLE pressing the button "
+                                "on the battery.")
+                return ExitCode.HARDWARE_WRONG_MODE
+            return boot_devs[0]
+        else:
+            self.logger.error(f"Invalid mode given: {mode_required}. This is most likely a bug in the code.")
+            return ExitCode.GENERIC_ERROR
 
-            # we have a device in normal mode, spin battery drivers and wait for info to be read
-            battery = Battery(lambda _: None, logger=self.logger)
-            self.register_shutdown_callback(battery.shutdown)
+    def _battery_obtain_info(self) -> int:
+        """Obtain battery related information
 
-            def watchdog_fcn():
-                timeout, elapsed, step = 10, 0, 0.5
-                while not (self.is_shutdown() or battery.is_shutdown()) and battery.info is None:
-                    if elapsed > timeout:
-                        break
-                    time.sleep(step)
-                    elapsed += step
-                battery.shutdown()
+        If successful, put battery info (e.g. PCB version and firmware version)
+        in the class attribute self._battery_info.
 
-            watchdog = Thread(target=watchdog_fcn)
-            watchdog.start()
+        Returns:
+            int: If success, ExitCode.SUCCESS. Otherwise, other ExitCodes.
+        """
 
-            try:
-                self.logger.debug(f"Trying to communicate with {ready_devs[0]}...")
-                battery.start(block=True, quiet=False)
-            except (OSError, serial.serialutil.SerialException) as e:
-                if "multiple access" in str(e):
-                    # battery is busy
-                    self.logger.error(
-                        "Battery detected but another process is using it. Make sure no other "
-                        "processes are communicating with the battery.")
-                    battery.shutdown()
-                    return ExitCode.HARDWARE_BUSY
-                # ---
-                self.logger.error(
-                    "An error occurred while talking to the battery, make sure "
-                    "no other processes are communicating with the battery.")
-                battery.shutdown()
-                return ExitCode.GENERIC_ERROR
+        # if info already read successfully, just return success
+        if self._battery_info is not None:
+            return ExitCode.SUCCESS
 
-            # if we are here, either we got the info or we timed out
+        # battery needs to be in READY mode for info/version reading
+        res = self._battery_device_mode_detect(mode_required=BatteryMode.READY)
+        if isinstance(res, int):  # if an ExitCode is returned
+            return res
+        # else, res is the ready mode device address
+
+        # battery READY. spin battery drivers and wait for info to be read
+        battery = Battery(lambda _: None, logger=self.logger)
+        self.register_shutdown_callback(battery.shutdown)
+
+        def watchdog_fcn():
+            timeout, elapsed, step = 10, 0, 0.5
+            while not (self.is_shutdown() or battery.is_shutdown()) and battery.info is None:
+                if elapsed > timeout:
+                    break
+                time.sleep(step)
+                elapsed += step
             battery.shutdown()
-            watchdog.join()
-            if battery.info is None:
-                self.logger.error(
-                    "An error occurred while talking to the battery, make sure "
-                    "no other processes are communicating with the battery.")
+
+        watchdog = Thread(target=watchdog_fcn)
+        watchdog.start()
+
+        try:
+            self.logger.debug(f"Trying to communicate with {res}...")
+            battery.start(block=True, quiet=False)
+        except (OSError, serial.serialutil.SerialException) as e:
+            if "multiple access" in str(e):
+                # battery is busy
+                self.logger.error((
+                    "Battery detected but another process is using it. "
+                    "Make sure no other process communicates with the battery."
+                ))
+                battery.shutdown()
+                return ExitCode.HARDWARE_BUSY
+            # ---
+            self.logger.error(
+                "An error occurred while talking to the battery, make sure "
+                "no other processes are communicating with the battery.")
+            battery.shutdown()
+            return ExitCode.GENERIC_ERROR
+
+        # if we are here, either we got the info or we timed out
+        battery.shutdown()
+        watchdog.join()
+        if battery.info is None:
+            self.logger.error(
+                "An error occurred while talking to the battery, make sure "
+                "no other processes are communicating with the battery.")
+            return ExitCode.GENERIC_ERROR
+
+        # store info in class attribute
+        self._battery_info = battery.info
+        return ExitCode.SUCCESS
+
+    def battery_find_pcb_version(self) -> int:
+        """Find PCB version of the battery
+
+        Returns:
+            int: If success, the pcb version (int) is returned, e.g. version "1.6" => 16.
+                 Otherwise, return 0 (PCB_VERSION_ID_EXIT_CODE_NONE).
+        """
+
+        res = self._battery_obtain_info()
+        if res != ExitCode.SUCCESS:
+            return PCB_VERSION_ID_EXIT_CODE_NONE
+
+        pcb_version = int(self._battery_info['boot']['pcb_version'])
+        self.logger.info(f"Fetched battery PCB version: {pcb_version}")
+
+        return pcb_version
+
+    def _battery_get_latest_firmware_version(self) -> Union[int, Tuple[int, str]]:
+        """Get latest firmware version
+
+        Two ways to obtain the "latest firmware"
+        1. supply a known firmware version
+            * with env variable FORCE_BATTERY_FW_VERSION
+        2. supply a PCB version, and use our API to check
+            a) with env variable PCB_VERSION
+            b) query the battery info for pcb version, with self.battery_find_pcb_version(...)
+
+        Among 2.a and 2.b, the reason to not always go with 2.b is:
+        In our duckietown-shell-commands duckiebot/battery/upgrade,
+        we use program exit/return codes to pass information along several steps.
+        Ideally:
+        - Step 1: find pcb version -> PCB version
+        - Step 2: check if firmware update is needed -> ExitCode.FIRMWARE_UP_TO_DATE or ExitCode.FIRMWARE_NEEDS_UPDATE
+        - Step 3: download and flash new firmware -> ExitCode.SUCCESS
+
+        And in Step 3, we need to download the latest firmware. For that,
+        we need to know the PCB version. (see constants.py/BATTERY_FIRMWARE_URL)
+
+        Since Step 3 also requires the BOOT mode, we cannot read the battery info.
+        So we need to pass the PCB_VERSION in somehow anyways.
+
+        In conclusion, 2.a is needed when upgrading battery with `dts`, and always works.
+        2.b just helps make calling the `--check` option easier (no need to do 2 separate things)
+
+        Returns:
+            Union[int, Tuple[int, str]]: If success, return (latest_fw_ver_int, latest_fw_ver_str).
+                                         Otherwise, non-SUCCESS ExitCodes.
+        """
+
+        # method 1
+        if os.environ.get("FORCE_BATTERY_FW_VERSION", default=None) is not None:
+            latest_str = os.environ.get("FORCE_BATTERY_FW_VERSION", default=None)
+            try:
+                latest_int = int(re.sub("[^0-9]+", "", latest_str))
+                self.logger.info(f"Firmware version forced to {latest_str}")
+                return latest_int, latest_str
+            except ValueError:
+                # something went wrong
+                self.logger.error("Error parsing the given version string. Exiting.")
                 return ExitCode.GENERIC_ERROR
 
-            # info is here
-            current_str = battery.info['version']
-            current_int = int(re.sub("[^0-9]+", "", current_str))
-            # print info and compare versions
-            print(BATTERY_INFO.format(current=f"v{current_str}", latest=latest_str))
-            return ExitCode.FIRMWARE_NEEDS_UPDATE if latest_int > current_int else \
-                ExitCode.FIRMWARE_UP_TO_DATE
+        def fetch_lateset_fw(pcb_version: int):
+            # get latest version available for a particular pcb version
+            latest_int, latest_str = self._get_latest_battery_firmware_available_for_pcb(pcb_version=pcb_version)
+            if latest_int is None:
+                # something went wrong
+                self.logger.error("Error fetching the latest firmware version available "
+                                "from the internet. Exiting.")
+                return ExitCode.GENERIC_ERROR
+            self.logger.debug(f"Latest version fetched from the cloud is {latest_str}")
+            return latest_int, latest_str
 
-        # boot mode enabled?
-        if len(boot_devs) <= 0:
-            # battery found but not in boot mode
-            self.logger.error("Battery detected in 'Normal Mode', but it needs to be in "
-                              "'Boot Mode'. You can switch mode by DOUBLE pressing the button "
-                              "on the battery.")
-            return ExitCode.HARDWARE_WRONG_MODE
-        # we have a device in boot mode, try opening connection to it
+        # method 2.a
+        if os.environ.get("PCB_VERSION") is not None:
+            pcb_ver = int(os.environ.get("PCB_VERSION"))
+            self.logger.info(f"PCB version supplied: {pcb_ver}")
+            return fetch_lateset_fw(pcb_version=pcb_ver)
+
+        # method 2.b
+        res = self.battery_find_pcb_version()
+        if res == PCB_VERSION_ID_EXIT_CODE_NONE:
+            self.logger.error("Cannot read battery PCB version")
+            return ExitCode.GENERIC_ERROR
+        self.logger.info(f"PCB version read: {res}")
+        return fetch_lateset_fw(pcb_version=res)
+
+    def battery_check_firmware_up_to_date(self) -> int:
+        """Check if battery firmware is up-to-date
+
+        Returns:
+            int: ExitCodes
+        """
+
+        # get current firmware info
+        res = self._battery_obtain_info()
+        if res != ExitCode.SUCCESS:
+            return res
+        # now the self._battery_info contains the firmware version
+        current_str = self._battery_info['version']
+        current_int = int(re.sub("[^0-9]+", "", current_str))
+
+        # get latest firmware for this version of PCB
+        res = self._battery_get_latest_firmware_version()
+        if isinstance(res, int):  # failed
+            return res
+        latest_int, latest_str = res
+
+        # print info and compare versions
+        print(BATTERY_INFO.format(current=f"v{current_str}", latest=latest_str))
+        if latest_int > current_int:
+            return ExitCode.FIRMWARE_NEEDS_UPDATE
+        else:
+            return ExitCode.FIRMWARE_UP_TO_DATE
+
+    def upgrade_battery(self,
+                        dryrun: bool = False,
+                        use_local_firmware: bool = False,
+                        ) -> int:
+
+        res = self._battery_device_mode_detect(mode_required=BatteryMode.BOOT)
+        if isinstance(res, int):  # failed with ExitCode
+            return res
+        # res contains the boot mode device addr
+        dev_addr = res
+
+        # try opening connection to it
         try:
-            with serial.Serial(boot_devs[0], BATTERY_PCB16_BAUD_RATE) as _:
+            with serial.Serial(dev_addr, BATTERY_PCB_BAUD_RATE) as _:
                 pass
         except (OSError, serial.serialutil.SerialException):
             # battery is busy
             self.logger.error("Battery detected but another process is using it. This should not "
                               "have happened. Contact the administrator.")
             return ExitCode.HARDWARE_BUSY
+
         if use_local_firmware:
             self.logger.info(f"In local firmware testing mode, will NOT download firmware from server.")
             # mounted repo path / preset firmware bin path
@@ -169,23 +334,38 @@ class UpgradeHelper(DTProcess):
             if not (os.path.exists(fw_fpath) and os.path.isfile(fw_fpath)):
                 self.logger.info(f"Error! Local firmware binary NOT FOUND at: {fw_fpath}")
                 return ExitCode.GENERIC_ERROR
-        else:
-            # download latest firmware
-            fw_filename = f"battery_pcb16_fw_v{latest_int}.bin"
+        else:  # download latest firmware
+            # the env variable PCB_VERSION has to be set
+            if os.environ.get("PCB_VERSION") is None:
+                self.logger.error("PCB_VERSION env variable not given. Abort.")
+                return ExitCode.GENERIC_ERROR
+
+            res = self._battery_get_latest_firmware_version()
+            if isinstance(res, int):  # failed
+                return res
+            latest_int, latest_str = res
+
+            pcb_ver = int(os.environ.get("PCB_VERSION"))
+            fw_filename = f"battery_pcb{pcb_ver}_fw_v{latest_int}.bin"
             fw_fpath = f"/tmp/{fw_filename}"
-            url = BATTERY_FIRMWARE_URL.format(pcb_version=16, resource=fw_filename)
+            url = BATTERY_FIRMWARE_URL.format(pcb_version=pcb_ver, resource=fw_filename)
             self.logger.info(f"Downloading firmware version {latest_str}...")
-            with open(fw_fpath, "wb") as fout:
-                # noinspection PyBroadException
-                try:
-                    fout.write(requests.get(url).content)
-                except BaseException as e:
-                    self.logger.error(f"ERROR: {str(e)}")
-                    return ExitCode.GENERIC_ERROR
-            self.logger.info("Firmware downloaded!")
+            try:
+                with open(fw_fpath, "wb") as fout:
+                    # noinspection PyBroadException
+                    try:
+                        fout.write(requests.get(url).content)
+                    except BaseException as e:
+                        self.logger.error(f"ERROR: {str(e)}")
+                        return ExitCode.GENERIC_ERROR
+                self.logger.info("Firmware downloaded!")
+            except Exception:
+                self.logger.error(f"Failed to download firmware. Error: {traceback.format_exc()}")
+                return ExitCode.GENERIC_ERROR
+
         self.logger.info(f"Using firmware file: {fw_fpath}")
         # everything should be ready to go
-        device = boot_devs[0].split('/')[-1]
+        device = dev_addr.split('/')[-1]
         self.logger.info(f"Flashing firmware to device {device}...")
         # compile command
         cmd = ["bossac",
@@ -217,8 +397,10 @@ class UpgradeHelper(DTProcess):
         return [p.device for p in ports]  # ['/dev/ttyACM0', ...]
 
     @staticmethod
-    def _get_latest_battery_firmware_available() -> Tuple[Optional[int], Optional[str]]:
-        url = BATTERY_FIRMWARE_URL.format(pcb_version=16, resource="latest")
+    def _get_latest_battery_firmware_available_for_pcb(
+        pcb_version: int,
+    ) -> Tuple[Optional[int], Optional[str]]:
+        url = BATTERY_FIRMWARE_URL.format(pcb_version=pcb_version, resource="latest")
         # noinspection PyBroadException
         try:
             latest = requests.get(url).text

--- a/packages/upgrade_helper/helper.py
+++ b/packages/upgrade_helper/helper.py
@@ -69,8 +69,6 @@ class UpgradeHelper(DTProcess):
                 return self.battery_check_firmware_up_to_date()
             # try to flash firmware
             return self.upgrade_battery(
-                parsed.find_pcbid,
-                parsed.check,
                 parsed.dry_run,
                 parsed.use_local_firmware,
             )

--- a/packages/upgrade_helper/helper.py
+++ b/packages/upgrade_helper/helper.py
@@ -253,7 +253,7 @@ class UpgradeHelper(DTProcess):
                 self.logger.error("Error parsing the given version string. Exiting.")
                 return ExitCode.GENERIC_ERROR
 
-        def fetch_lateset_fw(pcb_version: int):
+        def fetch_latest_fw(pcb_version: int):
             # get latest version available for a particular pcb version
             latest_int, latest_str = self._get_latest_battery_firmware_available_for_pcb(pcb_version=pcb_version)
             if latest_int is None:
@@ -268,7 +268,7 @@ class UpgradeHelper(DTProcess):
         if os.environ.get(ENV_KEY_PCB_VERSION) is not None:
             pcb_ver = int(os.environ.get(ENV_KEY_PCB_VERSION))
             self.logger.info(f"PCB version supplied: {pcb_ver}")
-            return fetch_lateset_fw(pcb_version=pcb_ver)
+            return fetch_latest_fw(pcb_version=pcb_ver)
 
         # method 2.b
         res = self.battery_find_pcb_version()
@@ -276,7 +276,7 @@ class UpgradeHelper(DTProcess):
             self.logger.error("Cannot read battery PCB version")
             return ExitCode.GENERIC_ERROR
         self.logger.info(f"PCB version read: {res}")
-        return fetch_lateset_fw(pcb_version=res)
+        return fetch_latest_fw(pcb_version=res)
 
     def battery_check_firmware_up_to_date(self) -> int:
         """Check if battery firmware is up-to-date

--- a/packages/upgrade_helper/helper.py
+++ b/packages/upgrade_helper/helper.py
@@ -28,6 +28,8 @@ from .constants import (
     BATTERY_FIRMWARE_URL,
     LOCAL_FIRMWARE_BIN_PATH,
     PCB_VERSION_ID_EXIT_CODE_NONE,
+    ENV_KEY_FORCE_FW_VERSION,
+    ENV_KEY_PCB_VERSION,
 )
 
 INFO = """
@@ -242,8 +244,8 @@ class UpgradeHelper(DTProcess):
         """
 
         # method 1
-        if os.environ.get("FORCE_BATTERY_FW_VERSION", default=None) is not None:
-            latest_str = os.environ.get("FORCE_BATTERY_FW_VERSION", default=None)
+        if os.environ.get(ENV_KEY_FORCE_FW_VERSION, default=None) is not None:
+            latest_str = os.environ.get(ENV_KEY_FORCE_FW_VERSION, default=None)
             try:
                 latest_int = int(re.sub("[^0-9]+", "", latest_str))
                 self.logger.info(f"Firmware version forced to {latest_str}")
@@ -265,8 +267,8 @@ class UpgradeHelper(DTProcess):
             return latest_int, latest_str
 
         # method 2.a
-        if os.environ.get("PCB_VERSION") is not None:
-            pcb_ver = int(os.environ.get("PCB_VERSION"))
+        if os.environ.get(ENV_KEY_PCB_VERSION) is not None:
+            pcb_ver = int(os.environ.get(ENV_KEY_PCB_VERSION))
             self.logger.info(f"PCB version supplied: {pcb_ver}")
             return fetch_lateset_fw(pcb_version=pcb_ver)
 
@@ -336,8 +338,8 @@ class UpgradeHelper(DTProcess):
                 return ExitCode.GENERIC_ERROR
         else:  # download latest firmware
             # the env variable PCB_VERSION has to be set
-            if os.environ.get("PCB_VERSION") is None:
-                self.logger.error("PCB_VERSION env variable not given. Abort.")
+            if os.environ.get(ENV_KEY_PCB_VERSION) is None:
+                self.logger.error(f"{ENV_KEY_PCB_VERSION} env variable not given. Abort.")
                 return ExitCode.GENERIC_ERROR
 
             res = self._battery_get_latest_firmware_version()
@@ -345,7 +347,7 @@ class UpgradeHelper(DTProcess):
                 return res
             latest_int, latest_str = res
 
-            pcb_ver = int(os.environ.get("PCB_VERSION"))
+            pcb_ver = int(os.environ.get(ENV_KEY_PCB_VERSION))
             fw_filename = f"battery_pcb{pcb_ver}_fw_v{latest_int}.bin"
             fw_fpath = f"/tmp/{fw_filename}"
             url = BATTERY_FIRMWARE_URL.format(pcb_version=pcb_ver, resource=fw_filename)

--- a/packages/upgrade_helper/main.py
+++ b/packages/upgrade_helper/main.py
@@ -6,7 +6,12 @@ from .helper import UpgradeHelper
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=(
+        "When trying to flash the Battery firmware, "
+        "first obtain the PCB version with --find-pcbid. "
+        "Then set the env variable PCB_VERSION to the above int, "
+        "for downloading the correct version of firmware."
+    ))
     # define parser arguments
     parser.add_argument(
         "--battery",
@@ -19,6 +24,12 @@ if __name__ == '__main__':
         action="store_true",
         default=False,
         help="Whether to update the HUT's firmware"
+    )
+    parser.add_argument(
+        "--find-pcbid",
+        action="store_true",
+        default=False,
+        help="Identify the PCB version"
     )
     parser.add_argument(
         "--check",


### PR DESCRIPTION
Tested on both PCBv16 and PCBv21. These are the tests for each battery:
* use `--find-pcbid` option, to obtain the PCB version in the return code
* use `--check` option, to see if battery firmware upgrade is needed (also via return code)
* use `--dry-run` option, to simulate a upgrade. But the firmware is not really flashed to the device.
* use no special options, to actually flash the battery with the latest firmware for that PCB

On PCBv21, an extra test is done with `--check`: when the PCB has firmware v2.0.2, this should result in `ExitCode.FIRMWARE_NEEDS_UPDATE` (which is `6`)

## Tests with PCBv16

### Find PCB version
```
root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --find-pcbid
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:Battery found at /dev/ttyACM0.
INFO:UpgradeHelper:Fetched battery PCB version: 16
root@autobot33:/code/dt-firmware-upgrade# echo $?
16
```

### Check firmware upgrade needed
```
root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --check
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:Battery found at /dev/ttyACM0.
INFO:UpgradeHelper:Fetched battery PCB version: 16
INFO:UpgradeHelper:PCB version read: 16

Duckietown Battery:
    - Current version:   v2.0.2
    - Available version: v2.0.2

root@autobot33:/code/dt-firmware-upgrade# echo $?
5
```

Note: in `packages/upgrade_helper/constants.py`, `ExitCode.FIRMWARE_UP_TO_DATE = 5`

### Dry-run firmware upgrade
```
root@autobot33:/code/dt-firmware-upgrade# export PCB_VERSION=16 && python3 -m upgrade_helper.main --battery --dry-run
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:PCB version supplied: 16
INFO:UpgradeHelper:Downloading firmware version v2.0.2...
INFO:UpgradeHelper:Firmware downloaded!
INFO:UpgradeHelper:Using firmware file: /tmp/battery_pcb16_fw_v202.bin
INFO:UpgradeHelper:Flashing firmware to device ttyACM0...
Atmel SMART device 0x10030000 found
Device       : ATSAMD11D14AM
Chip ID      : 10030000
Version      : v2.0 Dec 20 2018 15:51:25
Address      : 4096
Pages        : 192
Page Size    : 64 bytes
Total Size   : 12KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
Boot Flash   : true
BOD          : true
BOR          : true
INFO:UpgradeHelper:Done!
```

### Firmware flash
```
root@autobot33:/code/dt-firmware-upgrade# export PCB_VERSION=16 && python3 -m upgrade_helper.main --battery
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:PCB version supplied: 16
INFO:UpgradeHelper:Downloading firmware version v2.0.2...
INFO:UpgradeHelper:Firmware downloaded!
INFO:UpgradeHelper:Using firmware file: /tmp/battery_pcb16_fw_v202.bin
INFO:UpgradeHelper:Flashing firmware to device ttyACM0...
Atmel SMART device 0x10030000 found
Erase flash
done in 0.193 seconds

Write 12204 bytes to flash (191 pages)
[==============================] 100% (191/191 pages)
done in 2.321 seconds

Verify 12204 bytes of flash
[==============================] 100% (191/191 pages)
Verify successful
done in 0.066 seconds
CPU reset.
INFO:UpgradeHelper:Done!
```

## Tests with PCBv21

### Find PCB version
```
root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --find-pcbid
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:Battery found at /dev/ttyACM0.
INFO:UpgradeHelper:Fetched battery PCB version: 21
root@autobot33:/code/dt-firmware-upgrade# echo $?
21
``` 

### Check firmware upgrade needed
```
root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --check
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:Battery found at /dev/ttyACM0.
INFO:UpgradeHelper:Fetched battery PCB version: 21
INFO:UpgradeHelper:PCB version read: 21

Duckietown Battery:
    - Current version:   v2.0.3
    - Available version: v2.0.3

root@autobot33:/code/dt-firmware-upgrade# echo $?
5
```

Note: in `packages/upgrade_helper/constants.py`, `ExitCode.FIRMWARE_UP_TO_DATE = 5`

#### When the PCB actually has an old firmware
```
root@autobot33:/code/dt-firmware-upgrade# python3 -m upgrade_helper.main --battery --check
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:Battery found at /dev/ttyACM0.
INFO:UpgradeHelper:Fetched battery PCB version: 21
INFO:UpgradeHelper:PCB version read: 21

Duckietown Battery:
    - Current version:   v2.0.2
    - Available version: v2.0.3

root@autobot33:/code/dt-firmware-upgrade# echo $?
6
```

Note: in `packages/upgrade_helper/constants.py`, `ExitCode.FIRMWARE_NEEDS_UPDATE= 6`

### Dry-run firmware upgrade
```
root@autobot33:/code/dt-firmware-upgrade# export PCB_VERSION=21 && python3 -m upgrade_helper.main --battery --dry-run                                                                                                                                                                                                [25/2997]
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:PCB version supplied: 21
INFO:UpgradeHelper:Downloading firmware version v2.0.3...
INFO:UpgradeHelper:Firmware downloaded!
INFO:UpgradeHelper:Using firmware file: /tmp/battery_pcb21_fw_v203.bin
INFO:UpgradeHelper:Flashing firmware to device ttyACM0...
Atmel SMART device 0x10030000 found
Device       : ATSAMD11D14AM
Chip ID      : 10030000
Version      : v2.0 Dec 20 2018 15:51:25
Address      : 4096
Pages        : 192
Page Size    : 64 bytes
Total Size   : 12KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
Boot Flash   : true
BOD          : true
BOR          : true
INFO:UpgradeHelper:Done!
```

### Firmware flash
```
root@autobot33:/code/dt-firmware-upgrade# export PCB_VERSION=21 && python3 -m upgrade_helper.main --battery
INFO:UpgradeHelper:App status changed [INITIALIZING] -> [RUNNING]

Duckietown Battery Firmware Upgrade Utility.
Version 0.0.2

INFO:UpgradeHelper:PCB version supplied: 21
INFO:UpgradeHelper:Downloading firmware version v2.0.3...
INFO:UpgradeHelper:Firmware downloaded!
INFO:UpgradeHelper:Using firmware file: /tmp/battery_pcb21_fw_v203.bin
INFO:UpgradeHelper:Flashing firmware to device ttyACM0...
Atmel SMART device 0x10030000 found
Erase flash
done in 0.203 seconds

Write 12196 bytes to flash (191 pages)
[==============================] 100% (191/191 pages)
done in 2.363 seconds

Verify 12196 bytes of flash
[==============================] 100% (191/191 pages)
Verify successful
done in 0.067 seconds
CPU reset.
INFO:UpgradeHelper:Done!
```